### PR TITLE
Fix rails listening address in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails server -b 0.0.0.0
+web: bundle exec rails server -b ${RAILS_SERVER_LISTEN:-localhost}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
   app:
     image: alpinelab/ruby-dev:2.5.1
     ports: ["5000:5000"]
+    environment:
+      RAILS_SERVER_LISTEN: "0.0.0.0"
     volumes:
       - .:/app
       - bundle:/bundle


### PR DESCRIPTION
  Default is to listen on localhost (`::1` and `127.0.0.1`). Using
`0.0.0.0` will force IPv4 only and might expose a development server
publicly.

  We introduce `RAILS_SERVER_LISTEN` environment variable to configure a
specific address, and adapt docker compose configuration to set it as
`0.0.0.0`.
