### PR TITLE
Simplify web command in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails server -b ${RAILS_SERVER_LISTEN:-localhost}
+web: bundle exec rails server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: alpinelab/ruby-dev:2.5.1
     ports: ["5000:5000"]
     environment:
-      RAILS_SERVER_LISTEN: "0.0.0.0"
+      HOST: "0.0.0.0"
     volumes:
       - .:/app
       - bundle:/bundle


### PR DESCRIPTION
  Rails already supports `HOST` environment variable to change listening
address, so we don't need `RAILS_SERVER_LISTEN` and can rely on `rails
server` defaults, which would listen on all addresses with
`RAILS_ENV=production`.
