### PR TITLE
Add scaffold for basic models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "sass-rails", "~> 5.0"
 gem "uglifier", ">= 1.3.0"
 
 group :development, :test do
-  gem "alpinelab-codestyle", "~> 0.4"
+  gem "alpinelab-codestyle", "~> 0.5"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "rubocop", "~> 0.59"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    alpinelab-codestyle (0.4.0)
+    alpinelab-codestyle (0.5.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.5.0)
@@ -171,7 +171,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  alpinelab-codestyle (~> 0.4)
+  alpinelab-codestyle (~> 0.5)
   bootsnap (>= 1.1.0)
   byebug
   jbuilder (~> 2.5)

--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/dependencies.scss
+++ b/app/assets/stylesheets/dependencies.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dependencies controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[show edit update destroy]
+
+  # GET /comments
+  # GET /comments.json
+  def index
+    @comments = Comment.all
+  end
+
+  # GET /comments/1
+  # GET /comments/1.json
+  def show; end
+
+  # GET /comments/new
+  def new
+    @comment = Comment.new
+  end
+
+  # GET /comments/1/edit
+  def edit; end
+
+  # POST /comments
+  # POST /comments.json
+  def create
+    @comment = Comment.new(comment_params)
+
+    respond_to do |format|
+      if @comment.save
+        format.html do
+          redirect_to @comment, notice: "Comment was successfully created."
+        end
+        format.json do
+          render :show, status: :created, location: @comment
+        end
+      else
+        format.html do
+          render :new
+        end
+        format.json do
+          render json: @comment.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  # PATCH/PUT /comments/1
+  # PATCH/PUT /comments/1.json
+  def update
+    respond_to do |format|
+      if @comment.update(comment_params)
+        format.html do
+          redirect_to @comment, notice: "Comment was successfully updated."
+        end
+        format.json do
+          render :show, status: :ok, location: @comment
+        end
+      else
+        format.html do
+          render :edit
+        end
+        format.json do
+          render json: @comment.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  # DELETE /comments/1
+  # DELETE /comments/1.json
+  def destroy
+    @comment.destroy
+    respond_to do |format|
+      format.html { redirect_to comments_url, notice: "Comment was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def comment_params
+    params.require(:comment).permit(:body, :published, :dependency_id)
+  end
+end

--- a/app/controllers/dependencies_controller.rb
+++ b/app/controllers/dependencies_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class DependenciesController < ApplicationController
+  before_action :set_dependency, only: %i[show edit update destroy]
+
+  # GET /dependencies
+  # GET /dependencies.json
+  def index
+    @dependencies = Dependency.all
+  end
+
+  # GET /dependencies/1
+  # GET /dependencies/1.json
+  def show; end
+
+  # GET /dependencies/new
+  def new
+    @dependency = Dependency.new
+  end
+
+  # GET /dependencies/1/edit
+  def edit; end
+
+  # POST /dependencies
+  # POST /dependencies.json
+  def create
+    @dependency = Dependency.new(dependency_params)
+    respond_to do |format|
+      if @dependency.save
+        format.html do
+          redirect_to @dependency,
+            notice: "Dependency was successfully created."
+        end
+        format.json do
+          render :show, status: :created, location: @dependency
+        end
+      else
+        format.html do
+          render :new
+        end
+        format.json do
+          render json: @dependency.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  # PATCH/PUT /dependencies/1
+  # PATCH/PUT /dependencies/1.json
+  def update
+    respond_to do |format|
+      if @dependency.update(dependency_params)
+        format.html do
+          redirect_to @dependency,
+            notice: "Dependency was successfully updated."
+        end
+        format.json do
+          render :show, status: :ok, location: @dependency
+        end
+      else
+        format.html do
+          render :edit
+        end
+        format.json do
+          render json: @dependency.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
+  # DELETE /dependencies/1
+  # DELETE /dependencies/1.json
+  def destroy
+    @dependency.destroy
+    respond_to do |format|
+      format.html do
+        redirect_to dependencies_url,
+          notice: "Dependency was successfully destroyed."
+      end
+      format.json do
+        head :no_content
+      end
+    end
+  end
+
+private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_dependency
+    @dependency = Dependency.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet,
+  # only allow the white list through.
+  def dependency_params
+    params.require(:dependency).permit(:name)
+  end
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module CommentsHelper
+end

--- a/app/helpers/dependencies_helper.rb
+++ b/app/helpers/dependencies_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module DependenciesHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :dependency
+end

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Dependency < ApplicationRecord
+end

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Dependency < ApplicationRecord
+  has_many :comments, dependent: :destroy
 end

--- a/app/views/comments/_comment.json.jbuilder
+++ b/app/views/comments/_comment.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! comment, :id, :body, :published, :dependency_id, :created_at, :updated_at
+json.url comment_url(comment, format: :json)

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: comment, local: true) do |form| %>
+  <% if comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+
+      <ul>
+      <% comment.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :body %>
+    <%= form.text_area :body %>
+  </div>
+
+  <div class="field">
+    <%= form.label :published %>
+    <%= form.check_box :published %>
+  </div>
+
+  <div class="field">
+    <%= form.label :dependency_id %>
+    <%= form.text_field :dependency_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Comment</h1>
+
+<%= render 'form', comment: @comment %>
+
+<%= link_to 'Show', @comment %> |
+<%= link_to 'Back', comments_path %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Comments</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Body</th>
+      <th>Published</th>
+      <th>Dependency</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @comments.each do |comment| %>
+      <tr>
+        <td><%= comment.body %></td>
+        <td><%= comment.published %></td>
+        <td><%= comment.dependency %></td>
+        <td><%= link_to 'Show', comment %></td>
+        <td><%= link_to 'Edit', edit_comment_path(comment) %></td>
+        <td><%= link_to 'Destroy', comment, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Comment', new_comment_path %>

--- a/app/views/comments/index.json.jbuilder
+++ b/app/views/comments/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @comments, partial: "comments/comment", as: :comment

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Comment</h1>
+
+<%= render 'form', comment: @comment %>
+
+<%= link_to 'Back', comments_path %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Body:</strong>
+  <%= @comment.body %>
+</p>
+
+<p>
+  <strong>Published:</strong>
+  <%= @comment.published %>
+</p>
+
+<p>
+  <strong>Dependency:</strong>
+  <%= @comment.dependency %>
+</p>
+
+<%= link_to 'Edit', edit_comment_path(@comment) %> |
+<%= link_to 'Back', comments_path %>

--- a/app/views/comments/show.json.jbuilder
+++ b/app/views/comments/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "comments/comment", comment: @comment

--- a/app/views/dependencies/_dependency.json.jbuilder
+++ b/app/views/dependencies/_dependency.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! dependency, :id, :name, :created_at, :updated_at
+json.url dependency_url(dependency, format: :json)

--- a/app/views/dependencies/_form.html.erb
+++ b/app/views/dependencies/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: dependency, local: true) do |form| %>
+  <% if dependency.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(dependency.errors.count, "error") %> prohibited this dependency from being saved:</h2>
+
+      <ul>
+      <% dependency.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/dependencies/edit.html.erb
+++ b/app/views/dependencies/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Dependency</h1>
+
+<%= render 'form', dependency: @dependency %>
+
+<%= link_to 'Show', @dependency %> |
+<%= link_to 'Back', dependencies_path %>

--- a/app/views/dependencies/index.html.erb
+++ b/app/views/dependencies/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Dependencies</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @dependencies.each do |dependency| %>
+      <tr>
+        <td><%= dependency.name %></td>
+        <td><%= link_to 'Show', dependency %></td>
+        <td><%= link_to 'Edit', edit_dependency_path(dependency) %></td>
+        <td><%= link_to 'Destroy', dependency, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Dependency', new_dependency_path %>

--- a/app/views/dependencies/index.json.jbuilder
+++ b/app/views/dependencies/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @dependencies, partial: "dependencies/dependency", as: :dependency

--- a/app/views/dependencies/new.html.erb
+++ b/app/views/dependencies/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Dependency</h1>
+
+<%= render 'form', dependency: @dependency %>
+
+<%= link_to 'Back', dependencies_path %>

--- a/app/views/dependencies/show.html.erb
+++ b/app/views/dependencies/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @dependency.name %>
+</p>
+
+<%= link_to 'Edit', edit_dependency_path(@dependency) %> |
+<%= link_to 'Back', dependencies_path %>

--- a/app/views/dependencies/show.json.jbuilder
+++ b/app/views/dependencies/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "dependencies/dependency", dependency: @dependency

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :comments
   resources :dependencies
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :dependencies
 end

--- a/db/migrate/20180927084159_create_dependencies.rb
+++ b/db/migrate/20180927084159_create_dependencies.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDependencies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :dependencies do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180927110329_create_comments.rb
+++ b/db/migrate/20180927110329_create_comments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.boolean :published
+      t.references :dependency, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2018_09_27_084159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "dependencies", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_27_084159) do
+ActiveRecord::Schema.define(version: 2018_09_27_110329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.boolean "published"
+    t.bigint "dependency_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dependency_id"], name: "index_comments_on_dependency_id"
+  end
 
   create_table "dependencies", force: :cascade do |t|
     t.string "name"
@@ -21,4 +30,5 @@ ActiveRecord::Schema.define(version: 2018_09_27_084159) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "comments", "dependencies"
 end


### PR DESCRIPTION
This PR adds almost-untouched Rails-generated scaffolds
for dependencies (the new name for gems 😕) and comments.