### PR TITLE
Remove incorrect base path from HTTP API spec

### DIFF
--- a/doc/api-specification.yaml
+++ b/doc/api-specification.yaml
@@ -9,7 +9,6 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 host: 'localhost:5000'
-basePath: /
 tags:
   - name: dependency
     description: Everything about Dependencies


### PR DESCRIPTION
  Our HTTP API does not use a "base path" for now. When we specify `/`
as base path, and a `/dependencies` path, it means that the final path
is `//dependencies` (which does not exist).
