### PR TITLE
Remove operation identifiers in HTTP API spec

### DIFF
--- a/doc/api-specification.yaml
+++ b/doc/api-specification.yaml
@@ -27,7 +27,6 @@ paths:
         - dependency
       summary: Find dependency by ID
       description: Returns a single dependency
-      operationId: getDependencyById
       parameters:
         - name: dependencies_id
           in: path
@@ -47,7 +46,6 @@ paths:
         - dependency
       summary: Find all dependencies
       description: Returns all dependencies
-      operationId: getDependencies
       responses:
         '200':
           description: Successful operation
@@ -59,7 +57,6 @@ paths:
       tags:
         - dependency
       summary: Add a new dependency to the toolbox
-      operationId: addDependency
       parameters:
         - name: body
           in: body
@@ -85,7 +82,6 @@ paths:
         - comment
       summary: Find comment by ID
       description: Returns a single comment
-      operationId: getCommentById
       parameters:
         - name: dependencyId
           in: path
@@ -110,7 +106,6 @@ paths:
         - comment
       summary: Find all comments
       description: Returns all comment
-      operationId: getComments
       parameters:
         - name: dependencyId
           in: path
@@ -130,7 +125,6 @@ paths:
       tags:
         - comment
       summary: create a comment
-      operationId: addComment
       parameters:
         - name: dependencyId
           in: path


### PR DESCRIPTION
OpenAPI spec says:

> Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.

So I don't think we use or need them yet?
