### PR TITLE
Fix a bug in how we handle format in router

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :comments
   end
 
-  scope format: ENV.key?("ALLOW_FORMAT_FROM_URL") do
+  scope format: ENV.key?("ALLOW_FORMAT_FROM_URL") ? nil : false do
     scope module: :api, constraints: ->(req) { req.format == :json } do
       concerns :resources
     end


### PR DESCRIPTION
The `:format` option in the router (in a scope or on a resource) lets us define how the format of the request is determined, specifically how the `.:format` trailing dynamic segment is handled.

Actually (we previously thought otherwise):
* `format: true` makes this dynamic segment mandatory
* `format: false` disables this dynamic segment
* `format: nil` (default) makes it optional and uses the `Accept:` HTTP header to determine the format of the request when it is not present in the URL

So what we want is `format: false` (according to our HTTP API development guidelines) but we also want an easy way (an environment variable) to switch to `format: nil`. This is exactly what this commit does.