### PR TITLE
Cleanup Dockerfile

### DIFF
--- a/Dockerfile.dredd
+++ b/Dockerfile.dredd
@@ -1,17 +1,16 @@
-# FROM apiaryio/dredd:5.1.5
-# RUN apk add --no-cache --update ruby\
-# && gem install --no-document dredd_hooks json
 FROM ruby:2.5-alpine
-RUN apk add --update --virtual build-dependencies\
-      make\
-      gcc\
-      g++\
-      python\
-      git\
- && apk add --update --no-cache\
-      nodejs\
- && npm config set loglevel error\
- && npm install dredd\
- && apk del --purge build-dependencies\
- && gem install --no-document dredd_hooks
+
+RUN apk add --update --virtual build-dependencies \
+      make \
+      gcc \
+      g++ \
+      python \
+      git \
+ && apk add --update --no-cache \
+      nodejs \
+ && npm config set loglevel error \
+ && npm install dredd \
+ && gem install dredd_hooks \
+ && apk del --purge build-dependencies
+
 ENV PATH ${PATH}:/node_modules/.bin


### PR DESCRIPTION
This commit hopefully makes Dredd Dockerfile more readable by:
* removing commented code
* adding a blank line between directives
* adding a space before trailing slashes
* removing useless option `--no-document` from `gem install`
