### PR TITLE
Fix DockerFile installation script

### DIFF
--- a/Dockerfile.dredd
+++ b/Dockerfile.dredd
@@ -6,6 +6,7 @@ RUN apk add --update --virtual build-dependencies \
       g++ \
       python \
       git \
+      npm \
  && apk add --update --no-cache \
       nodejs \
  && npm config set loglevel error \


### PR DESCRIPTION
By adding explicitly 'npm' to packages list

Without this PR, step 2/3 of 1st `docker-compose up` raises an error:
`/bin/sh: npm: not found`